### PR TITLE
Revert ID rebasing and add a more verbose exception

### DIFF
--- a/src/main/java/com/tdunning/math/stats/Centroid.java
+++ b/src/main/java/com/tdunning/math/stats/Centroid.java
@@ -93,6 +93,14 @@ public class Centroid implements Comparable<Centroid> {
                 '}';
     }
 
+    public String toStringWithId() {
+        return "Centroid{" +
+                "centroid=" + centroid +
+                ", count=" + count +
+                ", id=" + id +
+                '}';
+    }
+
     @Override
     public int hashCode() {
         return id;

--- a/src/main/java/com/tdunning/math/stats/Centroid.java
+++ b/src/main/java/com/tdunning/math/stats/Centroid.java
@@ -27,19 +27,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class Centroid implements Comparable<Centroid> {
     private static final AtomicInteger uniqueCount = new AtomicInteger(1);
 
-    // Generate a random base for the ID. This will (with high probability) prevent collisions
-    // in the event of Centroids from two different JVM instances being merged (e.g. in a
-    // distributed system or across serialization/deserialization).
-    private static final long ID_BASE = ((long) new java.util.Random().nextInt()) << 32;
-
     private double centroid = 0;
     private int count = 0;
-    private long id;
+    private int id;
 
     private List<Double> actualData = null;
 
     Centroid(boolean record) {
-        id = ID_BASE + uniqueCount.getAndIncrement();
+        id = uniqueCount.getAndIncrement();
         if (record) {
             actualData = new ArrayList<Double>();
         }
@@ -66,7 +61,7 @@ public class Centroid implements Comparable<Centroid> {
     }
 
     private void start(double x, int w, int id) {
-        this.id = ID_BASE + id;
+        this.id = id;
         add(x, w);
     }
 
@@ -87,7 +82,7 @@ public class Centroid implements Comparable<Centroid> {
     }
 
     public int id() {
-        return ((int) (id & 0xFFFFFFFFL));
+        return id;
     }
 
     @Override
@@ -100,21 +95,14 @@ public class Centroid implements Comparable<Centroid> {
 
     @Override
     public int hashCode() {
-        return id();
+        return id;
     }
 
     @Override
     public int compareTo(Centroid o) {
         int r = Double.compare(centroid, o.centroid);
         if (r == 0) {
-            long idDiff = id - o.id;
-            if (idDiff < 0L) {
-                r = -1;
-            } else if (idDiff > 0L) {
-                r = 1;
-            } else {
-                r = 0;
-            }
+            r = id - o.id;
         }
         return r;
     }

--- a/src/main/java/com/tdunning/math/stats/GroupTree.java
+++ b/src/main/java/com/tdunning/math/stats/GroupTree.java
@@ -72,6 +72,10 @@ public class GroupTree extends AbstractCollection<Centroid> {
                 left = new GroupTree(leaf);
                 right = new GroupTree(centroid);
                 leaf = centroid;
+            } else {
+                String msg = String.format("centroid.compareTo(leaf)==0 caused NPE! centroid='%s', leaf='%s'",
+                        centroid.toStringWithId(), leaf.toStringWithId());
+                throw new NullPointerException(msg);
             }
         } else if (centroid.compareTo(leaf) < 0) {
             left.add(centroid);


### PR DESCRIPTION
The previous ID rebasing changes clearly didn't work, so this reverts them. The other change just adds a bit more info to the NPE.